### PR TITLE
Add stream support

### DIFF
--- a/client/nginx_client_test.go
+++ b/client/nginx_client_test.go
@@ -117,3 +117,116 @@ func TestDetermineUpdates(t *testing.T) {
 		}
 	}
 }
+
+func TestStreamDetermineUpdates(t *testing.T) {
+	var tests = []struct {
+		updated          []StreamUpstreamServer
+		nginx            []StreamUpstreamServer
+		expectedToAdd    []StreamUpstreamServer
+		expectedToDelete []StreamUpstreamServer
+	}{{
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		},
+		expectedToAdd: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		expectedToDelete: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		}}, {
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		},
+		expectedToAdd: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			}},
+		expectedToDelete: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			}},
+	}, {
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			}},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		}}, {
+	// empty values
+	}}
+
+	for _, test := range tests {
+		toAdd, toDelete := determineStreamUpdates(test.updated, test.nginx)
+		if !reflect.DeepEqual(toAdd, test.expectedToAdd) || !reflect.DeepEqual(toDelete, test.expectedToDelete) {
+			t.Errorf("determiteUpdates(%v, %v) = (%v, %v)", test.updated, test.nginx, toAdd, toDelete)
+		}
+	}
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,5 +51,6 @@ STOPSIGNAL SIGTERM
 
 RUN rm -rf /etc/nginx/conf.d/*
 COPY test.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,39 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+
+stream {
+    upstream stream_test {
+        zone stream 64k;
+    }
+
+}


### PR DESCRIPTION
Func requirements:
- [x] Check if a stream upstream exists
- [x] Add an upstream server for an upstream. When adding a server, a user must be able to configure max_fails, fail_timeout and slow_start parameters of an upstream server.
- [x] Delete an upstream server (by its [address]:[port]) of an upstream.
- [x] Get the list of upstream servers of an upstream
- [x] Update the upstream server of an upstream with the new list of upstream servers

Deliverables
- [x] Code
- [x] Unit tests
- [x] e2e tests 