### PR TITLE
Update to API v4 and fix stream endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NGINX_PLUS_VERSION=17-1
+NGINX_PLUS_VERSION=18-1
 NGINX_IMAGE=nginxplus:$(NGINX_PLUS_VERSION)
 
 test: docker-build run-nginx-plus test-run configure-no-stream-block test-run-no-stream-block clean
@@ -14,14 +14,16 @@ run-nginx-plus:
 
 test-run:
 	go test client/*
-	GOCACHE=off go test tests/client_test.go
+	go clean -testcache
+	go test tests/client_test.go 
 
 configure-no-stream-block:
 	docker cp docker/nginx_no_stream.conf nginx-plus-test:/etc/nginx/nginx.conf
 	docker exec nginx-plus-test nginx -s reload
 
 test-run-no-stream-block:
-	GOCACHE=off go test tests/client_no_stream_test.go
+	go clean -testcache
+	go test tests/client_no_stream_test.go
 
 clean:
 	docker kill nginx-plus-test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project includes a client library for working with NGINX Plus API.
 
 ## Compatibility
 
-This Client works against version 2 of NGINX Plus API. Version 2 was introduced in NGINX Plus R14.
+This Client works against version 4 of NGINX Plus API. Version 4 was introduced in NGINX Plus R18.
 
 ## Using the Client
 

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -10,9 +10,9 @@ import (
 )
 
 // APIVersion is a version of NGINX Plus API.
-const APIVersion = 2
+const APIVersion = 4
 
-const streamNotConfiguredCode = "StreamNotConfigured"
+const pathNotFoundCode = "PathNotFound"
 
 const streamContext = true
 const httpContext = false
@@ -44,16 +44,14 @@ type StreamUpstreamServer struct {
 }
 
 type apiErrorResponse struct {
-	Path      string
-	Method    string
 	Error     apiError
 	RequestID string `json:"request_id"`
 	Href      string
 }
 
 func (resp *apiErrorResponse) toString() string {
-	return fmt.Sprintf("path=%v; method=%v; error.status=%v; error.text=%v; error.code=%v; request_id=%v; href=%v",
-		resp.Path, resp.Method, resp.Error.Status, resp.Error.Text, resp.Error.Code, resp.RequestID, resp.Href)
+	return fmt.Sprintf("error.status=%v; error.text=%v; error.code=%v; request_id=%v; href=%v",
+		resp.Error.Status, resp.Error.Text, resp.Error.Code, resp.RequestID, resp.Href)
 }
 
 type apiError struct {
@@ -792,7 +790,7 @@ func (client *NginxClient) getStreamServerZones() (*StreamServerZones, error) {
 	err := client.get("stream/server_zones", &zones)
 	if err != nil {
 		if err, ok := err.(*internalError); ok {
-			if err.Code == streamNotConfiguredCode {
+			if err.Code == pathNotFoundCode {
 				return &zones, nil
 			}
 		}
@@ -815,7 +813,7 @@ func (client *NginxClient) getStreamUpstreams() (*StreamUpstreams, error) {
 	err := client.get("stream/upstreams", &upstreams)
 	if err != nil {
 		if err, ok := err.(*internalError); ok {
-			if err.Code == streamNotConfiguredCode {
+			if err.Code == pathNotFoundCode {
 				return &upstreams, nil
 			}
 		}


### PR DESCRIPTION
### Proposed changes
* Update API version to v4 (now min required NGINX Plus version for the go-client is R18)
* Fix the `stream` endpoints with the new error code (ref: https://github.com/nginxinc/nginx-prometheus-exporter/issues/45)
* Removed `GOCACHE` as this is not used in Go 1.12 anymore (ref: https://tip.golang.org/doc/go1.12#gocache)


PS: I think the tests that were already in `client_no_stream_test.go` cover the case of when the stream is not present as now we are returning an empty map of `StreamServerZones` or `StreamUpstreams` when path not found is returned as error.