### PR TITLE
Add zone sync endpoint to stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ docker-build:
 	docker build --build-arg NGINX_PLUS_VERSION=$(NGINX_PLUS_VERSION)~stretch -t $(NGINX_IMAGE) docker
 
 run-nginx-plus:
-	docker run -d --name nginx-plus-test --rm -p 8080:8080 -p 8081:8081 $(NGINX_IMAGE)
+	docker network create --driver bridge test
+	docker run --network=test -d --name nginx-plus-test --network-alias=nginx-plus-test --rm -p 8080:8080 -p 8081:8081 $(NGINX_IMAGE)
+	docker run --network=test -d --name nginx-plus-test-helper --network-alias=nginx-plus-test --rm -p 8090:8080 -p 8091:8081 $(NGINX_IMAGE)
 
 test-run:
 	go test client/*
@@ -26,4 +28,6 @@ test-run-no-stream-block:
 	go test tests/client_no_stream_test.go
 
 clean:
-	docker kill nginx-plus-test
+	-docker kill nginx-plus-test
+	-docker kill nginx-plus-test-helper
+	-docker network rm test

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run Tests:
 $ make test
 ```
 
-This will build and run an NGINX Plus container, execute the client tests against NGINX Plus API, and then clean up. If it fails and you want to clean up (i.e. stop the running container), please use `$ make clean`
+This will build and run two NGINX Plus containers and create one docker network of type bridge, execute the client tests against both NGINX Plus APIs, and then clean up. If it fails and you want to clean up (i.e. stop the running containers and remove the docker network), please use `$ make clean`
 
 ## Support
 This project is not covered by the NGINX Plus support contract.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -37,6 +37,7 @@ http {
 stream {
     keyval_zone zone=zone_one_stream:32k;
     keyval $hostname $text zone=zone_one_stream;
+    keyval_zone zone=zone_test_sync:32k timeout=5s sync;
 
     upstream stream_test {
         zone stream_test 64k;
@@ -49,4 +50,12 @@ stream {
         health_check interval=10 fails=3 passes=1;
     }
 
+    resolver 127.0.0.11 valid=5s;
+
+    server {
+        listen 7777;
+
+        zone_sync;
+        zone_sync_server nginx-plus-test:7777 resolve;
+    }
 }


### PR DESCRIPTION
### Proposed changes
Add Stream Zone Sync (http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_zone_sync) metrics in the client.



