### PR TITLE
Make zone sync struct optional

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -88,7 +88,7 @@ type Stats struct {
 	Upstreams         Upstreams
 	StreamServerZones StreamServerZones
 	StreamUpstreams   StreamUpstreams
-	StreamZoneSync    StreamZoneSync
+	StreamZoneSync    *StreamZoneSync
 }
 
 // NginxInfo contains general information about NGINX Plus.
@@ -764,7 +764,7 @@ func (client *NginxClient) GetStats() (*Stats, error) {
 		StreamServerZones: *streamZones,
 		Upstreams:         *upstreams,
 		StreamUpstreams:   *streamUpstreams,
-		StreamZoneSync:    *streamZoneSync,
+		StreamZoneSync:    streamZoneSync,
 	}, nil
 }
 
@@ -855,9 +855,8 @@ func (client *NginxClient) getStreamZoneSync() (*StreamZoneSync, error) {
 	err := client.get("stream/zone_sync", &streamZoneSync)
 	if err != nil {
 		if err, ok := err.(*internalError); ok {
-
 			if err.Code == pathNotFoundCode {
-				return &streamZoneSync, nil
+				return nil, nil
 			}
 		}
 		return nil, fmt.Errorf("failed to get stream zone sync: %v", err)

--- a/tests/client_no_stream_test.go
+++ b/tests/client_no_stream_test.go
@@ -34,4 +34,8 @@ func TestStatsNoStream(t *testing.T) {
 	if len(stats.StreamUpstreams) != 0 {
 		t.Error("No stream block should result in no StreamUpstreams")
 	}
+
+	if stats.StreamZoneSync != nil {
+		t.Error("No stream block should result in StreamZoneSync = `nil`")
+	}
 }

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -767,6 +767,10 @@ func TestStreamZoneSync(t *testing.T) {
 		t.Errorf("Error getting stats: %v", err)
 	}
 
+	if statsC1.StreamZoneSync == nil {
+		t.Errorf("Stream zone sync can't be nil if configured")
+	}
+
 	if statsC1.StreamZoneSync.Status.NodesOnline == 0 {
 		t.Errorf("At least 1 node must be online")
 	}
@@ -801,6 +805,10 @@ func TestStreamZoneSync(t *testing.T) {
 	statsC2, err := c2.GetStats()
 	if err != nil {
 		t.Errorf("Error getting stats: %v", err)
+	}
+
+	if statsC2.StreamZoneSync == nil {
+		t.Errorf("Stream zone sync can't be nil if configured")
 	}
 
 	if statsC2.StreamZoneSync.Status.NodesOnline == 0 {


### PR DESCRIPTION
### Proposed changes
NGINX Plus does not return StreamZoneSync metrics if there is no sync zone configured. Because of this, we need to make these a pointer to the struct so we can check if the metrics are present or not (instead of returning an empty struct with zeroes)

This will require the user to be careful when using the `Stats.StreamZoneSync` field, as it can be `nil`.
