### PR TITLE
Fix session metrics for stream upstreams

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -184,8 +184,8 @@ type Responses struct {
 // Sessions represents stream session related stats.
 type Sessions struct {
 	Sessions2xx uint64 `json:"2xx"`
-	Sessions4xx uint64 `josn:"4xx"`
-	Sessions5xx uint64 `josn:"5xx"`
+	Sessions4xx uint64 `json:"4xx"`
+	Sessions5xx uint64 `json:"5xx"`
 	Total       uint64
 }
 


### PR DESCRIPTION
### Proposed changes
* `4xx` and `5xx` session metrics are not correctly unmarshalled. Instead
they are ignored. This is due to a typo.

Bug introduced in: https://github.com/nginxinc/nginx-plus-go-client/commit/c9fb4acf9c4aeb238b2e9121aecf9c4dbe525676


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
