### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.0 (July 17, 2019)
+FEATURES:
+* [24](https://github.com/nginxinc/nginx-plus-go-client/pull/24): *Support `MaxConns` in upstream servers*.
+
+BUGFIXES:
+* [25](https://github.com/nginxinc/nginx-plus-go-client/pull/25): *Fix session metrics for stream upstreams*. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.
+
 ## 0.3.1 (June 10, 2019)
 CHANGES:
 * [22](https://github.com/nginxinc/nginx-plus-go-client/pull/22): *Change in stream zone sync metrics*. `StreamZoneSync` field of the `Stats` type is now a pointer. It will be nil if NGINX Plus doesn't report any zone sync stats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ FEATURES:
 * [24](https://github.com/nginxinc/nginx-plus-go-client/pull/24): *Support `MaxConns` in upstream servers*.
 
 BUGFIXES:
-* [25](https://github.com/nginxinc/nginx-plus-go-client/pull/25): *Fix session metrics for stream upstreams*. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.
+* [25](https://github.com/nginxinc/nginx-plus-go-client/pull/25): *Fix session metrics for stream server zones*. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.
 
 ## 0.3.1 (June 10, 2019)
 CHANGES:


### PR DESCRIPTION
### Proposed changes
#### FEATURES:
* Support `MaxConns` in upstream servers.

#### BUGFIXES:
* Fix session metrics for stream server zones. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.
