### PR TITLE
Fix MaxFails default and Add test coverage for UpstreamServers

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -30,7 +30,7 @@ type UpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    int    `json:"max_fails,omitempty"`
+	MaxFails    *int   `json:"max_fails"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }
@@ -40,7 +40,7 @@ type StreamUpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    int    `json:"max_fails,omitempty"`
+	MaxFails    *int   `json:"max_fails"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }
@@ -386,6 +386,11 @@ func (client *NginxClient) AddHTTPServer(upstream string, server UpstreamServer)
 		return fmt.Errorf("failed to add %v server to %v upstream: server already exists", server.Server, upstream)
 	}
 
+	if server.MaxFails == nil {
+		defaultMaxFails := 1
+		server.MaxFails = &defaultMaxFails
+	}
+
 	path := fmt.Sprintf("http/upstreams/%v/servers/", upstream)
 	err = client.post(path, &server)
 	if err != nil {
@@ -609,6 +614,11 @@ func (client *NginxClient) AddStreamServer(upstream string, server StreamUpstrea
 	}
 	if id != -1 {
 		return fmt.Errorf("failed to add %v stream server to %v upstream: server already exists", server.Server, upstream)
+	}
+
+	if server.MaxFails == nil {
+		defaultMaxFails := 1
+		server.MaxFails = &defaultMaxFails
 	}
 
 	path := fmt.Sprintf("stream/upstreams/%v/servers/", upstream)

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -17,6 +17,8 @@ const pathNotFoundCode = "PathNotFound"
 const streamContext = true
 const httpContext = false
 
+var defaultMaxFails = 1
+
 // NginxClient lets you access NGINX Plus API.
 type NginxClient struct {
 	apiEndpoint string
@@ -387,7 +389,6 @@ func (client *NginxClient) AddHTTPServer(upstream string, server UpstreamServer)
 	}
 
 	if server.MaxFails == nil {
-		defaultMaxFails := 1
 		server.MaxFails = &defaultMaxFails
 	}
 
@@ -617,7 +618,6 @@ func (client *NginxClient) AddStreamServer(upstream string, server StreamUpstrea
 	}
 
 	if server.MaxFails == nil {
-		defaultMaxFails := 1
 		server.MaxFails = &defaultMaxFails
 	}
 

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -30,7 +30,7 @@ type UpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    int    `json:"max_fails"`
+	MaxFails    int    `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }
@@ -40,7 +40,7 @@ type StreamUpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    int    `json:"max_fails"`
+	MaxFails    int    `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -17,8 +17,6 @@ const pathNotFoundCode = "PathNotFound"
 const streamContext = true
 const httpContext = false
 
-var defaultMaxFails = 1
-
 // NginxClient lets you access NGINX Plus API.
 type NginxClient struct {
 	apiEndpoint string
@@ -32,7 +30,7 @@ type UpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    *int   `json:"max_fails"`
+	MaxFails    *int   `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }
@@ -42,7 +40,7 @@ type StreamUpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
 	MaxConns    int    `json:"max_conns"`
-	MaxFails    *int   `json:"max_fails"`
+	MaxFails    *int   `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
 }
@@ -388,10 +386,6 @@ func (client *NginxClient) AddHTTPServer(upstream string, server UpstreamServer)
 		return fmt.Errorf("failed to add %v server to %v upstream: server already exists", server.Server, upstream)
 	}
 
-	if server.MaxFails == nil {
-		server.MaxFails = &defaultMaxFails
-	}
-
 	path := fmt.Sprintf("http/upstreams/%v/servers/", upstream)
 	err = client.post(path, &server)
 	if err != nil {
@@ -615,10 +609,6 @@ func (client *NginxClient) AddStreamServer(upstream string, server StreamUpstrea
 	}
 	if id != -1 {
 		return fmt.Errorf("failed to add %v stream server to %v upstream: server already exists", server.Server, upstream)
-	}
-
-	if server.MaxFails == nil {
-		server.MaxFails = &defaultMaxFails
 	}
 
 	path := fmt.Sprintf("stream/upstreams/%v/servers/", upstream)

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -196,7 +196,7 @@ func TestStreamUpstreamServer(t *testing.T) {
 		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
 	}
 
-	// remove upstream servers
+	// remove stream upstream servers
 	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
 	if err != nil {
 		t.Errorf("Couldn't remove servers: %v", err)
@@ -362,7 +362,6 @@ func TestUpstreamServer(t *testing.T) {
 		t.Fatalf("Error connecting to nginx: %v", err)
 	}
 
-	// Add a server with slow_start
 	maxFails := 64
 	server := client.UpstreamServer{
 		Server:      "127.0.0.1:2000",

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -16,6 +16,8 @@ const (
 	streamZoneSync = "zone_test_sync"
 )
 
+var defaultMaxFails = 1
+
 func TestStreamClient(t *testing.T) {
 	httpClient := &http.Client{}
 	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
@@ -490,7 +492,12 @@ func TestUpstreamServerDefaultParameters(t *testing.T) {
 		Server: "127.0.0.1:2000",
 	}
 
-	expected := createDefaultUpstreamServer()
+	expected := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "0s",
+		MaxFails:    &defaultMaxFails,
+		FailTimeout: "10s",
+	}
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)
@@ -597,7 +604,12 @@ func TestStreamUpstreamServerDefaultParameters(t *testing.T) {
 		Server: "127.0.0.1:2000",
 	}
 
-	expected := createDefaultStreamUpstreamServer()
+	expected := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "0s",
+		MaxFails:    &defaultMaxFails,
+		FailTimeout: "10s",
+	}
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)
@@ -943,24 +955,4 @@ func compareStreamUpstreamServers(x []client.StreamUpstreamServer, y []client.St
 	}
 
 	return reflect.DeepEqual(xServers, yServers)
-}
-
-func createDefaultUpstreamServer() client.UpstreamServer {
-	defaultMaxFails := 1
-	return client.UpstreamServer{
-		Server:      "127.0.0.1:2000",
-		SlowStart:   "0s",
-		MaxFails:    &defaultMaxFails,
-		FailTimeout: "10s",
-	}
-}
-
-func createDefaultStreamUpstreamServer() client.StreamUpstreamServer {
-	defaultMaxFails := 1
-	return client.StreamUpstreamServer{
-		Server:      "127.0.0.1:2000",
-		SlowStart:   "0s",
-		MaxFails:    &defaultMaxFails,
-		FailTimeout: "10s",
-	}
 }

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -161,7 +161,6 @@ func TestStreamClient(t *testing.T) {
 	}
 }
 
-// Test adding the slow_start property on an upstream server
 func TestStreamUpstreamServerSlowStart(t *testing.T) {
 	httpClient := &http.Client{}
 	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
@@ -177,6 +176,128 @@ func TestStreamUpstreamServerSlowStart(t *testing.T) {
 		SlowStart:   "11s",
 		MaxFails:    1,
 		FailTimeout: "10s",
+	}
+	err = c.AddStreamServer(streamUpstream, streamServer)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error getting stream servers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(streamServer, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestStreamUpstreamServerMaxConns(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with max_conns
+	// (And SlowStart, since the default is 0s)
+	// (And MaxFails, since the default is 1)
+	// (And FailTimeout, since the default is 10s)
+	streamServer := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "0s",
+		MaxConns:    16,
+		MaxFails:    1,
+		FailTimeout: "10s",
+	}
+	err = c.AddStreamServer(streamUpstream, streamServer)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error getting stream servers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(streamServer, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestStreamUpstreamServerMaxFails(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with max_fails
+	// (And FailTimeout, since the default is 10s)
+	streamServer := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		MaxFails:    32,
+		FailTimeout: "10s",
+	}
+	err = c.AddStreamServer(streamUpstream, streamServer)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error getting stream servers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(streamServer, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestStreamUpstreamServerFailTimeout(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with fail_timeout
+	streamServer := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		MaxFails:    1,
+		FailTimeout: "20s",
 	}
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
@@ -355,7 +476,127 @@ func TestClient(t *testing.T) {
 	}
 }
 
-// Test adding the slow_start property on an upstream server
+func TestUpstreamServerMaxConns(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with max_conns
+	// (And FailTimeout, since the default is 10s)
+	// (And MaxFails, sice the default is 1)
+	server := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		MaxFails:    1,
+		FailTimeout: "10s",
+		MaxConns:    64,
+	}
+	err = c.AddHTTPServer(upstream, server)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error getting HTTPServers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(server, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", server, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestUpstreamServerMaxFails(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with max_fails
+	// (And FailTimeout, since the default is 10s)
+	server := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		MaxFails:    16,
+		FailTimeout: "10s",
+	}
+	err = c.AddHTTPServer(upstream, server)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error getting HTTPServers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(server, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", server, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestUpstreamServerFailTimeout(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with fail_timeout
+	server := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		MaxFails:    16,
+		FailTimeout: "15s",
+	}
+	err = c.AddHTTPServer(upstream, server)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error getting HTTPServers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(server, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", server, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
 func TestUpstreamServerSlowStart(t *testing.T) {
 	httpClient := &http.Client{}
 	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -240,7 +240,7 @@ func TestStreamUpstreamServerMaxFails(t *testing.T) {
 
 	// Add a server with max_fails
 	streamServer := createDefaultStreamUpstreamServer()
-	streamServer.MaxFails = 32
+	*streamServer.MaxFails = 32
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)
@@ -497,7 +497,7 @@ func TestUpstreamServerMaxFails(t *testing.T) {
 
 	// Add a server with max_fails
 	server := createDefaultUpstreamServer()
-	server.MaxFails = 16
+	*server.MaxFails = 16
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)
@@ -1145,19 +1145,21 @@ func compareStreamUpstreamServers(x []client.StreamUpstreamServer, y []client.St
 }
 
 func createDefaultUpstreamServer() client.UpstreamServer {
+	defaultMaxFails := 1
 	return client.UpstreamServer{
 		Server:      "127.0.0.1:2000",
 		SlowStart:   "0s",
-		MaxFails:    1,
+		MaxFails:    &defaultMaxFails,
 		FailTimeout: "10s",
 	}
 }
 
 func createDefaultStreamUpstreamServer() client.StreamUpstreamServer {
+	defaultMaxFails := 1
 	return client.StreamUpstreamServer{
 		Server:      "127.0.0.1:2000",
 		SlowStart:   "0s",
-		MaxFails:    1,
+		MaxFails:    &defaultMaxFails,
 		FailTimeout: "10s",
 	}
 }

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -161,121 +161,21 @@ func TestStreamClient(t *testing.T) {
 	}
 }
 
-func TestStreamUpstreamServerSlowStart(t *testing.T) {
+func TestStreamUpstreamServer(t *testing.T) {
 	httpClient := &http.Client{}
 	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
 	if err != nil {
 		t.Fatalf("Error connecting to nginx: %v", err)
 	}
 
-	// Add a server with slow_start
-	streamServer := createDefaultStreamUpstreamServer()
-	streamServer.SlowStart = "11s"
-	err = c.AddStreamServer(streamUpstream, streamServer)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
+	maxFails := 64
+	streamServer := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		MaxConns:    321,
+		MaxFails:    &maxFails,
+		FailTimeout: "21s",
+		SlowStart:   "12s",
 	}
-	servers, err := c.GetStreamServers(streamUpstream)
-	if err != nil {
-		t.Fatalf("Error getting stream servers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(streamServer, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestStreamUpstreamServerMaxConns(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with max_conns
-	streamServer := createDefaultStreamUpstreamServer()
-	streamServer.MaxConns = 16
-	err = c.AddStreamServer(streamUpstream, streamServer)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
-	}
-	servers, err := c.GetStreamServers(streamUpstream)
-	if err != nil {
-		t.Fatalf("Error getting stream servers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(streamServer, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestStreamUpstreamServerMaxFails(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with max_fails
-	streamServer := createDefaultStreamUpstreamServer()
-	*streamServer.MaxFails = 32
-	err = c.AddStreamServer(streamUpstream, streamServer)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
-	}
-	servers, err := c.GetStreamServers(streamUpstream)
-	if err != nil {
-		t.Fatalf("Error getting stream servers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(streamServer, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestStreamUpstreamServerFailTimeout(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with fail_timeout
-	streamServer := createDefaultStreamUpstreamServer()
-	streamServer.FailTimeout = "20s"
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)
@@ -453,112 +353,7 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func TestUpstreamServerMaxConns(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with max_conns
-	server := createDefaultUpstreamServer()
-	server.MaxConns = 64
-	err = c.AddHTTPServer(upstream, server)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
-	}
-	servers, err := c.GetHTTPServers(upstream)
-	if err != nil {
-		t.Fatalf("Error getting HTTPServers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(server, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", server, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestUpstreamServerMaxFails(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with max_fails
-	server := createDefaultUpstreamServer()
-	*server.MaxFails = 16
-	err = c.AddHTTPServer(upstream, server)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
-	}
-	servers, err := c.GetHTTPServers(upstream)
-	if err != nil {
-		t.Fatalf("Error getting HTTPServers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(server, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", server, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestUpstreamServerFailTimeout(t *testing.T) {
-	httpClient := &http.Client{}
-	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
-	if err != nil {
-		t.Fatalf("Error connecting to nginx: %v", err)
-	}
-
-	// Add a server with fail_timeout
-	server := createDefaultUpstreamServer()
-	server.FailTimeout = "15s"
-	err = c.AddHTTPServer(upstream, server)
-	if err != nil {
-		t.Errorf("Error adding upstream server: %v", err)
-	}
-	servers, err := c.GetHTTPServers(upstream)
-	if err != nil {
-		t.Fatalf("Error getting HTTPServers: %v", err)
-	}
-	if len(servers) != 1 {
-		t.Errorf("Too many servers")
-	}
-	// don't compare IDs
-	servers[0].ID = 0
-
-	if !reflect.DeepEqual(server, servers[0]) {
-		t.Errorf("Expected: %v Got: %v", server, servers[0])
-	}
-
-	// remove upstream servers
-	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
-	if err != nil {
-		t.Errorf("Couldn't remove servers: %v", err)
-	}
-}
-
-func TestUpstreamServerSlowStart(t *testing.T) {
+func TestUpstreamServer(t *testing.T) {
 	httpClient := &http.Client{}
 	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
 	if err != nil {
@@ -566,8 +361,14 @@ func TestUpstreamServerSlowStart(t *testing.T) {
 	}
 
 	// Add a server with slow_start
-	server := createDefaultUpstreamServer()
-	server.SlowStart = "11s"
+	maxFails := 64
+	server := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		MaxConns:    321,
+		MaxFails:    &maxFails,
+		FailTimeout: "21s",
+		SlowStart:   "12s",
+	}
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
 		t.Errorf("Error adding upstream server: %v", err)


### PR DESCRIPTION
### Proposed changes
* Fix MaxFails in UpstreamServer and StreamUpstreamServer. Previously the default was `0` as opposed to the intended `1`.
* Improve test coverage for UpstreamServer and StreamUpstreamServer. The following cases were added
  * Adding defaultUpstream
  * Setting MaxConns
  * Setting MaxFails
  * Setting FailTimeout

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
