### PR TITLE
Add Additional Upstream Server Parameters

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -33,6 +33,12 @@ type UpstreamServer struct {
 	MaxFails    *int   `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
+	Route       string `json:"route"`
+	Backup      bool   `json:"backup"`
+	Down        bool   `json:"down"`
+	Drain       bool   `json:"drain,omitempty"`
+	Weight      *int   `json:"weight,omitempty"`
+	Service     string `json:"service,omitempty"`
 }
 
 // StreamUpstreamServer lets you configure Stream upstreams.
@@ -43,6 +49,10 @@ type StreamUpstreamServer struct {
 	MaxFails    *int   `json:"max_fails,omitempty"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
+	Backup      bool   `json:"backup"`
+	Down        bool   `json:"down"`
+	Weight      *int   `json:"weight,omitempty"`
+	Service     string `json:"service,omitempty"`
 }
 
 type apiErrorResponse struct {

--- a/docker/test.conf
+++ b/docker/test.conf
@@ -18,4 +18,11 @@ server {
         health_check interval=10 fails=3 passes=1;
     }
     status_zone test;
+
+}
+
+upstream test-drain {
+    zone test-drain 64k;
+
+    server 127.0.0.1:9001 drain;
 }


### PR DESCRIPTION
Fixes #28

### Proposed changes
Extend the go client to support additional parameters in upstream servers:

`route`
`backup`
`down`
`drain`
`weight`
`service`

Make sure that when adding an upstream server with unspecified parameters, the values of those parameters in NGINX Plus API are set with their default values.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
