### PR TITLE
Fix Dockerfile location in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - "ciarams87"
       - "sundaram1995"
   - package-ecosystem: "docker"
-    directory: "/build"
+    directory: "/docker"
     schedule:
       interval: daily
     reviewers:


### PR DESCRIPTION
Wrong path for docker
