### PR TITLE
Update Dockerfile, NGINX and golangci-lint versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NGINX_PLUS_VERSION=23-1
+NGINX_PLUS_VERSION=r24
 NGINX_IMAGE=nginxplus:$(NGINX_PLUS_VERSION)
 DOCKER_NETWORK?=test
 DOCKER_NETWORK_ALIAS=nginx-plus-test
@@ -6,7 +6,7 @@ DOCKER_NGINX_PLUS?=nginx-plus
 DOCKER_NGINX_PLUS_HELPER?=nginx-plus-helper
 
 GOLANG_CONTAINER=golang:1.16
-GOLANGCI_CONTAINER=golangci/golangci-lint:v1.38-alpine
+GOLANGCI_CONTAINER=golangci/golangci-lint:latest
 
 export TEST_API_ENDPOINT=http://$(DOCKER_NGINX_PLUS):8080/api
 export TEST_API_ENDPOINT_OF_HELPER=http://$(DOCKER_NGINX_PLUS_HELPER):8080/api
@@ -21,7 +21,7 @@ lint:
 	$(GOLANGCI_CONTAINER) golangci-lint run
 
 docker-build:
-	docker build --build-arg NGINX_PLUS_VERSION=$(NGINX_PLUS_VERSION)~stretch -t $(NGINX_IMAGE) docker
+	docker build --secret id=nginx-repo.crt,src=nginx-repo.crt --secret id=nginx-repo.key,src=nginx-repo.key --build-arg NGINX_PLUS_VERSION=$(NGINX_PLUS_VERSION) -t $(NGINX_IMAGE) docker
 
 run-nginx-plus:
 	docker network create --driver bridge $(DOCKER_NETWORK)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,53 +1,32 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ARG NGINX_PLUS_VERSION
 
-# Download certificate and key from the customer portal (https://cs.nginx.com)
-# and copy to the build context
-COPY nginx-repo.crt /etc/ssl/nginx/
-COPY nginx-repo.key /etc/ssl/nginx/
-
-# Make sure the certificate and key have correct permissions
-RUN chmod 644 /etc/ssl/nginx/*
-
 # Install NGINX Plus
-RUN set -x \
-  && apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y apt-transport-https ca-certificates gnupg1 \
-  && \
-  NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
-  found=''; \
-  for server in \
-    ha.pool.sks-keyservers.net \
-    hkp://keyserver.ubuntu.com:80 \
-    hkp://p80.pool.sks-keyservers.net:80 \
-    pgp.mit.edu \
-  ; do \
-    echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-    apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
-  done; \
-  test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
-  echo "Acquire::https::plus-pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
-  && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
-  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION} \
-  && apt-get remove --purge --auto-remove -y gnupg1 \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /etc/ssl/nginx \
-  && rm /etc/apt/apt.conf.d/90nginx /etc/apt/sources.list.d/nginx-plus.list
+# Download certificate and key from the customer portal (https://my.f5.com)
+# and copy to the build context
+RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
+    --mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
+    apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
+    && curl -sSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
+    && curl -sSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
+    && printf "%s\n" "deb https://pkgs.nginx.com/plus/debian buster nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
+    && apt-get update && apt-get install -y nginx-plus-${NGINX_PLUS_VERSION} \
+    && apt-get remove --purge --auto-remove -y gnupg \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /etc/apt/apt.conf.d/90pkgs-nginx /etc/apt/sources.list.d/nginx-plus.list
 
 
 # Forward request logs to Docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 RUN rm -rf /etc/nginx/conf.d/*
 COPY test.conf /etc/nginx/conf.d/


### PR DESCRIPTION
- Update NGINX Plus to R24
- Updated Docker base image to buster
- Mount nginx cert and key at build time instead of copying into the container
- Updated golangci-lint to use latest
