### PR TITLE
Fix virtual package error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
     && curl -sSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
     && curl -sSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
     && DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
-	&& printf "%s\n" "Acquire::https::pkgs.nginx.com::User-Agent \"k8s-ic-$IC_VERSION${BUILD_OS##debian-plus}-apt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
-	&& printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
+    && printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
     && apt-get update && apt-get install -y nginx-plus-${NGINX_PLUS_VERSION} \
     && apt-get remove --purge --auto-remove -y gnupg \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,9 @@ RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode
     && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
     && curl -sSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
     && curl -sSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
-    && printf "%s\n" "deb https://pkgs.nginx.com/plus/debian buster nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
+    && DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
+	&& printf "%s\n" "Acquire::https::pkgs.nginx.com::User-Agent \"k8s-ic-$IC_VERSION${BUILD_OS##debian-plus}-apt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+	&& printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
     && apt-get update && apt-get install -y nginx-plus-${NGINX_PLUS_VERSION} \
     && apt-get remove --purge --auto-remove -y gnupg \
     && rm -rf /var/lib/apt/lists/* \

--- a/tests/client_no_stream_test.go
+++ b/tests/client_no_stream_test.go
@@ -21,7 +21,7 @@ func TestStatsNoStream(t *testing.T) {
 
 	stats, err := c.GetStats()
 	if err != nil {
-		t.Errorf("Error getting stats: %w", err)
+		t.Errorf("Error getting stats: %v", err)
 	}
 
 	if stats.Connections.Accepted < 1 {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -69,7 +69,7 @@ func TestStreamClient(t *testing.T) {
 
 	streamServers, err := c.GetStreamServers(streamUpstream)
 	if err != nil {
-		t.Errorf("Error getting stream servers: %w", err)
+		t.Errorf("Error getting stream servers: %v", err)
 	}
 	if len(streamServers) != 0 {
 		t.Errorf("Expected 0 servers, got %v", streamServers)
@@ -275,7 +275,7 @@ func TestStreamUpstreamServer(t *testing.T) {
 	}
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
-		t.Errorf("Error adding upstream server: %w", err)
+		t.Errorf("Error adding upstream server: %v", err)
 	}
 	servers, err := c.GetStreamServers(streamUpstream)
 	if err != nil {
@@ -294,7 +294,7 @@ func TestStreamUpstreamServer(t *testing.T) {
 	// remove stream upstream servers
 	_, _, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove servers: %w", err)
+		t.Errorf("Couldn't remove servers: %v", err)
 	}
 }
 
@@ -551,7 +551,7 @@ func TestUpstreamServer(t *testing.T) {
 	}
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
-		t.Errorf("Error adding upstream server: %w", err)
+		t.Errorf("Error adding upstream server: %v", err)
 	}
 	servers, err := c.GetHTTPServers(upstream)
 	if err != nil {
@@ -570,7 +570,7 @@ func TestUpstreamServer(t *testing.T) {
 	// remove upstream servers
 	_, _, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove servers: %w", err)
+		t.Errorf("Couldn't remove servers: %v", err)
 	}
 }
 
@@ -586,12 +586,12 @@ func TestStats(t *testing.T) {
 	}
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
-		t.Errorf("Error adding upstream server: %w", err)
+		t.Errorf("Error adding upstream server: %v", err)
 	}
 
 	stats, err := c.GetStats()
 	if err != nil {
-		t.Errorf("Error getting stats: %w", err)
+		t.Errorf("Error getting stats: %v", err)
 	}
 
 	// NginxInfo
@@ -689,7 +689,7 @@ func TestStats(t *testing.T) {
 	// cleanup upstream servers
 	_, _, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove servers: %w", err)
+		t.Errorf("Couldn't remove servers: %v", err)
 	}
 }
 
@@ -720,7 +720,7 @@ func TestUpstreamServerDefaultParameters(t *testing.T) {
 	}
 	err = c.AddHTTPServer(upstream, server)
 	if err != nil {
-		t.Errorf("Error adding upstream server: %w", err)
+		t.Errorf("Error adding upstream server: %v", err)
 	}
 	servers, err := c.GetHTTPServers(upstream)
 	if err != nil {
@@ -739,7 +739,7 @@ func TestUpstreamServerDefaultParameters(t *testing.T) {
 	// remove upstream servers
 	_, _, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove servers: %w", err)
+		t.Errorf("Couldn't remove servers: %v", err)
 	}
 }
 
@@ -755,13 +755,13 @@ func TestStreamStats(t *testing.T) {
 	}
 	err = c.AddStreamServer(streamUpstream, server)
 	if err != nil {
-		t.Errorf("Error adding stream upstream server: %w", err)
+		t.Errorf("Error adding stream upstream server: %v", err)
 	}
 
 	// make connection so we have stream server zone stats - ignore response
 	_, err = net.Dial("tcp", helpers.GetStreamAddress())
 	if err != nil {
-		t.Errorf("Error making tcp connection: %w", err)
+		t.Errorf("Error making tcp connection: %v", err)
 	}
 
 	// wait for health checks
@@ -769,7 +769,7 @@ func TestStreamStats(t *testing.T) {
 
 	stats, err := c.GetStats()
 	if err != nil {
-		t.Errorf("Error getting stats: %w", err)
+		t.Errorf("Error getting stats: %v", err)
 	}
 
 	if stats.Connections.Active == 0 {
@@ -809,7 +809,7 @@ func TestStreamStats(t *testing.T) {
 	// cleanup stream upstream servers
 	_, _, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove stream servers: %w", err)
+		t.Errorf("Couldn't remove stream servers: %v", err)
 	}
 }
 
@@ -838,7 +838,7 @@ func TestStreamUpstreamServerDefaultParameters(t *testing.T) {
 	}
 	err = c.AddStreamServer(streamUpstream, streamServer)
 	if err != nil {
-		t.Errorf("Error adding upstream server: %w", err)
+		t.Errorf("Error adding upstream server: %v", err)
 	}
 	streamServers, err := c.GetStreamServers(streamUpstream)
 	if err != nil {
@@ -857,7 +857,7 @@ func TestStreamUpstreamServerDefaultParameters(t *testing.T) {
 	// cleanup stream upstream servers
 	_, _, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
 	if err != nil {
-		t.Errorf("Couldn't remove stream servers: %w", err)
+		t.Errorf("Couldn't remove stream servers: %v", err)
 	}
 }
 
@@ -871,7 +871,7 @@ func TestKeyValue(t *testing.T) {
 
 	err = c.AddKeyValPair(zoneName, "key1", "val1")
 	if err != nil {
-		t.Errorf("Couldn't set keyvals: %w", err)
+		t.Errorf("Couldn't set keyvals: %v", err)
 	}
 
 	var keyValPairs client.KeyValPairs
@@ -888,7 +888,7 @@ func TestKeyValue(t *testing.T) {
 
 	keyValuPairsByZone, err := c.GetAllKeyValPairs()
 	if err != nil {
-		t.Errorf("Couldn't get keyvals, %w", err)
+		t.Errorf("Couldn't get keyvals, %v", err)
 	}
 	expectedKeyValPairsByZone := client.KeyValPairsByZone{
 		zoneName: expectedKeyValPairs,
@@ -901,12 +901,12 @@ func TestKeyValue(t *testing.T) {
 	expectedKeyValPairs["key1"] = "valModified1"
 	err = c.ModifyKeyValPair(zoneName, "key1", "valModified1")
 	if err != nil {
-		t.Errorf("couldn't set keyval: %w", err)
+		t.Errorf("couldn't set keyval: %v", err)
 	}
 
 	keyValPairs, err = c.GetKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	if !reflect.DeepEqual(expectedKeyValPairs, keyValPairs) {
 		t.Errorf("maps are not equal. expected: %+v, got: %+v", expectedKeyValPairs, keyValPairs)
@@ -920,7 +920,7 @@ func TestKeyValue(t *testing.T) {
 
 	err = c.AddKeyValPair(zoneName, "key2", "val2")
 	if err != nil {
-		t.Errorf("error adding another key/val pair: %w", err)
+		t.Errorf("error adding another key/val pair: %v", err)
 	}
 
 	err = c.DeleteKeyValuePair(zoneName, "key1")
@@ -933,7 +933,7 @@ func TestKeyValue(t *testing.T) {
 	}
 	keyValPairs, err = c.GetKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	if !reflect.DeepEqual(keyValPairs, expectedKeyValPairs2) {
 		t.Errorf("didn't delete key1 %+v", keyValPairs)
@@ -941,12 +941,12 @@ func TestKeyValue(t *testing.T) {
 
 	err = c.DeleteKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't delete all: %w", err)
+		t.Errorf("couldn't delete all: %v", err)
 	}
 
 	keyValPairs, err = c.GetKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	if len(keyValPairs) > 0 {
 		t.Errorf("zone should be empty after bulk delete")
@@ -969,7 +969,7 @@ func TestKeyValueStream(t *testing.T) {
 
 	err = c.AddStreamKeyValPair(zoneName, "key1", "val1")
 	if err != nil {
-		t.Errorf("Couldn't set keyvals: %w", err)
+		t.Errorf("Couldn't set keyvals: %v", err)
 	}
 
 	keyValPairs, err := c.GetStreamKeyValPairs(zoneName)
@@ -985,7 +985,7 @@ func TestKeyValueStream(t *testing.T) {
 
 	keyValPairsByZone, err := c.GetAllStreamKeyValPairs()
 	if err != nil {
-		t.Errorf("Couldn't get keyvals, %w", err)
+		t.Errorf("Couldn't get keyvals, %v", err)
 	}
 	expectedKeyValuePairsByZone := client.KeyValPairsByZone{
 		zoneName:       expectedKeyValPairs,
@@ -999,12 +999,12 @@ func TestKeyValueStream(t *testing.T) {
 	expectedKeyValPairs["key1"] = "valModified1"
 	err = c.ModifyStreamKeyValPair(zoneName, "key1", "valModified1")
 	if err != nil {
-		t.Errorf("couldn't set keyval: %w", err)
+		t.Errorf("couldn't set keyval: %v", err)
 	}
 
 	keyValPairs, err = c.GetStreamKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	if !reflect.DeepEqual(expectedKeyValPairs, keyValPairs) {
 		t.Errorf("maps are not equal. expected: %+v, got: %+v", expectedKeyValPairs, keyValPairs)
@@ -1018,7 +1018,7 @@ func TestKeyValueStream(t *testing.T) {
 
 	err = c.AddStreamKeyValPair(zoneName, "key2", "val2")
 	if err != nil {
-		t.Errorf("error adding another key/val pair: %w", err)
+		t.Errorf("error adding another key/val pair: %v", err)
 	}
 
 	err = c.DeleteStreamKeyValuePair(zoneName, "key1")
@@ -1028,7 +1028,7 @@ func TestKeyValueStream(t *testing.T) {
 
 	keyValPairs, err = c.GetStreamKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	expectedKeyValPairs2 := client.KeyValPairs{
 		"key2": "val2",
@@ -1039,12 +1039,12 @@ func TestKeyValueStream(t *testing.T) {
 
 	err = c.DeleteStreamKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't delete all: %w", err)
+		t.Errorf("couldn't delete all: %v", err)
 	}
 
 	keyValPairs, err = c.GetStreamKeyValPairs(zoneName)
 	if err != nil {
-		t.Errorf("couldn't get keyval: %w", err)
+		t.Errorf("couldn't get keyval: %v", err)
 	}
 	if len(keyValPairs) > 0 {
 		t.Errorf("zone should be empty after bulk delete")
@@ -1070,7 +1070,7 @@ func TestStreamZoneSync(t *testing.T) {
 
 	err = c1.AddStreamKeyValPair(streamZoneSync, "key1", "val1")
 	if err != nil {
-		t.Errorf("Couldn't set keyvals: %w", err)
+		t.Errorf("Couldn't set keyvals: %v", err)
 	}
 
 	// wait for nodes to sync information of synced zones
@@ -1078,7 +1078,7 @@ func TestStreamZoneSync(t *testing.T) {
 
 	statsC1, err := c1.GetStats()
 	if err != nil {
-		t.Errorf("Error getting stats: %w", err)
+		t.Errorf("Error getting stats: %v", err)
 	}
 
 	if statsC1.StreamZoneSync == nil {
@@ -1118,7 +1118,7 @@ func TestStreamZoneSync(t *testing.T) {
 
 	statsC2, err := c2.GetStats()
 	if err != nil {
-		t.Errorf("Error getting stats: %w", err)
+		t.Errorf("Error getting stats: %v", err)
 	}
 
 	if statsC2.StreamZoneSync == nil {


### PR DESCRIPTION
### Proposed changes

This commit fixes the below error we have been seeing in the pipeline by pulling the virtual package from the version specific repo:

```
#11 11.69 Package nginx-plus-r25 is a virtual package provided by:
#11 11.69   nginx-plus 25-2~buster [Not candidate version]
#11 11.69   nginx-plus 25-1~buster [Not candidate version]
#11 11.69 
#11 11.75 E: Package 'nginx-plus-r25' has no installation candidate
```

