### PR TITLE
Use here-documents style in Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,16 @@ jobs:
           sed -i "17i && sed -i 's|pkgs|pkgs-test|g' /etc/apt/apt.conf.d/90pkgs-nginx \\\ " docker/Dockerfile
           sed -i 's|deb https|deb [trusted=yes] https|g' docker/Dockerfile
           sed -i 's|nginx-plus-\${{ env.NGINX_PLUS_VERSION }}|nginx-plus|g' docker/Dockerfile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build Plus Docker Image
         uses: docker/build-push-action@v2
         with:
           file: docker/Dockerfile
           context: 'docker'
           tags: nginx-plus:${{ env.NGINX_PLUS_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           load: true
           secrets: |
             "nginx-repo.crt=${{ secrets.NGINX_CRT }}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 FROM debian:bullseye-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
@@ -8,20 +8,21 @@ ARG NGINX_PLUS_VERSION
 # Install NGINX Plus
 # Download certificate and key from the customer portal (https://my.f5.com)
 # and copy to the build context
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=secret,id=nginx-repo.crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
     --mount=type=secret,id=nginx-repo.key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
-    apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https \
-    && curl -sSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg \
-    && curl -sSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx \
-    && DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release) \
-    && printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list \
-    && apt-get update && apt-get install -y nginx-plus-${NGINX_PLUS_VERSION} \
-    && apt-get remove --purge --auto-remove -y gnupg \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm /etc/apt/apt.conf.d/90pkgs-nginx /etc/apt/sources.list.d/nginx-plus.list
-
+    <<"eot" bash -euo pipefail
+    apt-get update
+    apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl apt-transport-https
+    curl -fsSL https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor > /etc/apt/trusted.gpg.d/nginx_signing.gpg
+    curl -fsSL -o /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx
+    DEBIAN_VERSION=$(awk -F '=' '/^VERSION_CODENAME=/ {print $2}' /etc/os-release)
+    printf "%s\n" "deb https://pkgs.nginx.com/plus/${NGINX_PLUS_VERSION^^}/debian ${DEBIAN_VERSION} nginx-plus" > /etc/apt/sources.list.d/nginx-plus.list
+    apt-get update
+    apt-get install -y nginx-plus-${NGINX_PLUS_VERSION}
+    apt-get remove --purge --auto-remove -y gnupg
+    rm -rf /var/lib/apt/lists/*
+    rm /etc/apt/apt.conf.d/90pkgs-nginx /etc/apt/sources.list.d/nginx-plus.list
+eot
 
 # Forward request logs to Docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
@@ -32,7 +33,7 @@ EXPOSE 80
 STOPSIGNAL SIGQUIT
 
 RUN rm -rf /etc/nginx/conf.d/*
-COPY test.conf /etc/nginx/conf.d/
-COPY nginx.conf /etc/nginx/
+COPY --link test.conf /etc/nginx/conf.d/
+COPY --link nginx.conf /etc/nginx/
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Dockerfile 1.4 now supports using here-documents https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#here-documents

This improves readability without all the `&&` and `\`
