### PR TITLE
Release 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main
@@ -28,9 +30,7 @@ jobs:
   build:
     name: Build Client
     runs-on: ubuntu-20.04
-    if:
-      github.event.pull_request.head.repo.full_name == 'nginxinc/nginx-plus-go-client' ||
-      github.event_name == 'push' || github.event_name == 'schedule'
+    if: ${{ github.event.repository.fork == false }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -69,3 +69,23 @@ jobs:
         run: make test
         env:
           NGINX_PLUS_VERSION: nightly
+
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Publish Release Notes
+        uses: release-drafter/release-drafter@v5
+        with:
+            publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Visual Studio Code settings
 .vscode
+
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,10 @@
+builds:
+  - skip: true
+
+changelog:
+  skip: true
+
+announce:
+  slack:
+    enabled: true
+    channel: '#general'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.10.0 (Jul 19, 2022)
+
+An automatically generated list of changes can be found on GitHub at: [0.10.0 Release](https://github.com/nginxinc/nginx-plus-go-client/releases/tag/v0.10.0)
+
+## 0.9.0 (Sep 28, 2021)
+
+An automatically generated list of changes can be found on GitHub at: [0.9.0 Release](https://github.com/nginxinc/nginx-plus-go-client/releases/tag/v0.9.0)
+
+## 0.8.0 (Nov 26, 2020)
+
+An automatically generated list of changes can be found on GitHub at: [0.8.0 Release](https://github.com/nginxinc/nginx-plus-go-client/releases/tag/v0.8.0)
+
 ## 0.7.0 (Jul 10, 2020)
 FEATURES:
 * [38](https://github.com/nginxinc/nginx-plus-go-client/pull/38): *Support for /slabs API endpoint*. The client now supports retrieving shared memory zone usage info.
@@ -42,7 +54,7 @@ CHANGES:
 
 ## 0.3 (May 29, 2019)
 FEATURES:
-* [20](https://github.com/nginxinc/nginx-plus-go-client/pull/20): *Support for stream zone sync metrics*. The client `GetStats` method now additionally returns stream zone sync metrics. 
+* [20](https://github.com/nginxinc/nginx-plus-go-client/pull/20): *Support for stream zone sync metrics*. The client `GetStats` method now additionally returns stream zone sync metrics.
 * [13](https://github.com/nginxinc/nginx-plus-go-client/pull/13): *Support for key-value endpoints*. The client implements a set of methods to create/modify/delete key-val pairs for both http and stream contexts.
 * [12](https://github.com/nginxinc/nginx-plus-go-client/pull/12) *Support for NGINX status info*. The client `GetStats` method now additionally returns NGINX status metrics. Thanks to [jthurman42](https://github.com/jthurman42).
 


### PR DESCRIPTION
Docs and workflow changes for release `0.10.0`. 

Additionally:
- Added automatic publish on tag with release drafter
- GoReleaser used to announce the release on the community slack channel
