### PR TITLE
Create default NGINX API Client with specified Timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .vscode
 
 dist
+
+coverage.out
+

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,15 @@ export TEST_API_ENDPOINT=http://$(DOCKER_NGINX_PLUS):8080/api
 export TEST_API_ENDPOINT_OF_HELPER=http://$(DOCKER_NGINX_PLUS_HELPER):8080/api
 export TEST_UNAVAILABLE_STREAM_ADDRESS=$(DOCKER_NGINX_PLUS):8081
 
-test: run-nginx-plus test-run configure-no-stream-block test-run-no-stream-block clean
+
+test: run-nginx-plus test-run configure-no-stream-block test-run-no-stream-block clean ## Run integration tests
+
+unittest:
+	go test client/*.go -shuffle=on -race -v
+
+cover:
+	go test -shuffle=on -race -v client/*.go -count=1 -cover -covermode=atomic -coverprofile=coverage.out
+	go tool cover -html coverage.out
 
 lint:
 	docker run --pull always --rm -v $(shell pwd):/nginx-plus-go-client -w /nginx-plus-go-client -v $(shell go env GOCACHE):/cache/go -e GOCACHE=/cache/go -e GOLANGCI_LINT_CACHE=/cache/go -v $(shell go env GOPATH)/pkg:/go/pkg golangci/golangci-lint:latest golangci-lint --color always run

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ import "github.com/nginxinc/nginx-plus-go-client/client"
 
 ## Creating a client
 
-Create a new ```Client``` that works with the latest NGINX API Version:
+When creating a new ```client``` it is assumed that NGINX API is reachable. The ```client``` verifies API version of the running NGINX at the time of creating a new client object.
+
+If user wants to create a client without NGINX automatic version check it should use the ```NewDefaultNginxClient``` func to create the client.
+
+
+### Create a new ```Client``` that works with the latest NGINX API Version:
 ```go
 myHTTPClient := &http.Client{
     Timeout: 5*time.Second
@@ -41,7 +46,7 @@ if err != nil {
 }
 ```
 
-Create a new ```Client``` with specified API version:
+### Create a new ```Client``` with specified API version:
 ```go
 myHTTPClient := &http.Client{
     Timeout: 5*time.Second
@@ -53,16 +58,14 @@ if err != nil {
 }
 ```
 
-
-
-Create a new default ```Client```:
+### Create a new default ```Client``` that does not check NGINX API version:
 ```go
 c, err := client.NewDefaultNginxClient("your-api-endpoint")
 if err != nil {
 	// handle error
 }
 ```
-Create a new default client with customized http.Client and API Version:
+### Create a new default client with customized ```http.Client``` and API Version:
 ```go
 myHTTPClient := &http.Client{
 	Timeout: 60 * time.Second,
@@ -79,7 +82,7 @@ if err != nil {
 ```
 Note that:
 - default NGINX Plus Client is using ```http.Client``` with specified ```Timeout``` value of 10s
-- it is user's responsibility to provide correct NGINX API version
+- it is user's responsibility to provide correct NGINX API version as the ```NewDefaultNginxClient``` func does not verify the version
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,76 @@ This Client works against versions 4 to 8 of the NGINX Plus API. The table below
 | 7 | R25 |
 | 8 | R27 |
 
-## Using the Client
+## Using the client library
 
-1. Import `github.com/nginxinc/nginx-plus-go-client/client` into your go project.
-2. Use your favorite vendor tool to add this to your `/vendor` directory in your project.
+Import the library using:
+```go
+import "github.com/nginxinc/nginx-plus-go-client/client"
+```
+
+## Creating a client
+
+Create a new ```Client``` that works with the latest NGINX API Version:
+```go
+myHTTPClient := &http.Client{
+    Timeout: 5*time.Second
+}
+c, err := NewNginxClient(myHTTPClient, "your-api-endpoint")
+if err != nil {
+    // handle error
+}
+```
+
+Create a new ```Client``` with specified API version:
+```go
+myHTTPClient := &http.Client{
+    Timeout: 5*time.Second
+}
+
+c, err := NewNginxClientWithVersion(myHTTPClient, "your-api-endpoint", 7)
+if err != nil {
+    // handle error
+}
+```
+
+
+
+Create a new default ```Client```:
+```go
+c, err := client.NewDefaultNginxClient("your-api-endpoint")
+if err != nil {
+	// handle error
+}
+```
+Create a new default client with customized http.Client and API Version:
+```go
+myHTTPClient := &http.Client{
+	Timeout: 60 * time.Second,
+}
+
+c, err := client.NewDefaultNginxClient(
+	"your-api-endpoint",
+	client.WithHTTPClient(myHTTPClient),
+	client.WithAPIVersion(7),
+)
+if err != nil {
+	// handle error
+}
+```
+Note that:
+- default NGINX Plus Client is using ```http.Client``` with specified ```Timeout``` value of 10s
+- it is user's responsibility to provide correct NGINX API version
 
 ## Testing
 
 ### Unit tests
+Run unittests
 ```
-$ cd client
-$ go test
+$ make unittest
+```
+Run unittests with coverage report
+```
+$ make cover
 ```
 
 ### Integration tests

--- a/examples/default-client/main.go
+++ b/examples/default-client/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/nginxinc/nginx-plus-go-client/client"
+)
+
+func main() {
+	// Create a custom HTTP Client
+	myHTTPClient := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+
+	// Create NGINX Plus Client for working with version 8
+	c, err := client.NewDefaultNginxClient(
+		"https://demo.nginx.com/api",
+		client.WithHTTPClient(myHTTPClient),
+		client.WithAPIVersion(8),
+	)
+	if err != nil {
+		// handle error
+		log.Fatal(err)
+	}
+
+	// Retrieve info about running NGINX
+	info, err := c.GetNginxInfo()
+	if err != nil {
+		// handle error
+		log.Fatal(err)
+	}
+	fmt.Printf("%+v\n", info)
+
+	// Prints
+	// &{Version:1.21.6 Build:nginx-plus-r27 Address:3.125.64.247 Generation:4 LoadTimestamp:2022-09-14T12:45:25.218Z Timestamp:2022-10-10T12:25:16.552Z ProcessID:3640888 ParentProcessID:2945895}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/nginxinc/nginx-plus-go-client
 
 go 1.19
+
+require github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
### Proposed changes

- Added ability to create a new default NGINX API Client with a default ```http.Client``` configured with 10s timeout.
- Updated docs
- Added examples of how to use the default client

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
