### PR TITLE
Fix api support range in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ functions.
 
 ## Compatibility
 
-This Client works against versions 4 to 8 of the NGINX Plus API. The table below shows the version of NGINX Plus where
+This Client works against versions 4 to 9 of the NGINX Plus API. The table below shows the version of NGINX Plus where
 the API was first introduced.
 
 | API version | NGINX Plus version |


### PR DESCRIPTION
### Proposed changes

* Fix api support range in readme to include api version `9` since: https://github.com/nginxinc/nginx-plus-go-client/commit/80901b0dc044939e6423e81f20f3baedf697747c

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
