### PR TITLE
Add checks to see if stream endpoints exist before calling them

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -1151,7 +1151,7 @@ func determineStreamUpdates(updatedServers []StreamUpstreamServer, nginxServers 
 
 // GetStats gets process, slab, connection, request, ssl, zone, stream zone, upstream and stream upstream related stats from the NGINX Plus API.
 func (client *NginxClient) GetStats() (*Stats, error) {
-	endpoints, err := client.GetAvailableEndpoint()
+	endpoints, err := client.GetAvailableEndpoints()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stats: %w", err)
 	}
@@ -1232,7 +1232,7 @@ func (client *NginxClient) GetStats() (*Stats, error) {
 	streamZoneSync := &StreamZoneSync{}
 
 	if slices.Contains(endpoints, "stream") {
-		streamEndpoints, err := client.GetAvailableStreamEndpoint()
+		streamEndpoints, err := client.GetAvailableStreamEndpoints()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get stats: %w", err)
 		}
@@ -1288,8 +1288,8 @@ func (client *NginxClient) GetStats() (*Stats, error) {
 	}, nil
 }
 
-// GetAvailableEndpoint returns available endpoints in the API.
-func (client *NginxClient) GetAvailableEndpoint() ([]string, error) {
+// GetAvailableEndpoints returns available endpoints in the API.
+func (client *NginxClient) GetAvailableEndpoints() ([]string, error) {
 	var endpoints []string
 	err := client.get("", &endpoints)
 	if err != nil {
@@ -1298,8 +1298,8 @@ func (client *NginxClient) GetAvailableEndpoint() ([]string, error) {
 	return endpoints, nil
 }
 
-// GetAvailableStreamEndpoint returns available stream endpoints in the API.
-func (client *NginxClient) GetAvailableStreamEndpoint() ([]string, error) {
+// GetAvailableStreamEndpoints returns available stream endpoints in the API.
+func (client *NginxClient) GetAvailableStreamEndpoints() ([]string, error) {
 	var endpoints []string
 	err := client.get("stream", &endpoints)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/nginxinc/nginx-plus-go-client
 
 go 1.19
+
+require golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=


### PR DESCRIPTION
### Proposed changes

This changes is required for the use case where someone doesn't have streams configured in their nginx.conf and want to prevent 404 errors from being logged in the NGINX access log.

```
127.0.0.1 - - [05/Oct/2023:13:10:29 +0000] "GET /api//8/stream/upstreams HTTP/1.1" 404 183 "-" "Go-http-client/1.1" "-"
127.0.0.1 - - [05/Oct/2023:13:10:29 +0000] "GET /api//8/stream/zone_sync HTTP/1.1" 404 183 "-" "Go-http-client/1.1" "-"
127.0.0.1 - - [05/Oct/2023:13:10:29 +0000] "GET /api//8/stream/limit_conns HTTP/1.1" 404 183 "-" "Go-http-client/1.1" "-"
127.0.0.1 - - [05/Oct/2023:13:10:44 +0000] "GET /api//8/stream/server_zones HTTP/1.1" 404 183 "-" "Go-http-client/1.1" "-"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
