### PR TITLE
Bump Go to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-    strategy:
-      matrix:
-        go-version: ["1.19", "1.20", "1.21"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -39,7 +36,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
 
       - name: Run Unit Tests
         run: make unit-test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,11 @@ jobs:
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      - name: Setup Golang Environment
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: go.mod
+
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -9,10 +9,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
-
-	"slices"
 )
 
 const (

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/nginxinc/nginx-plus-go-client
 
-go 1.19
-
-require golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+go 1.21.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=


### PR DESCRIPTION
### Proposed changes

Updates the version of go and removes external `slices` dependency that is now part of go `1.21`
