### PR TITLE
Bump labeler to v5.0.0 and update config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,12 +12,15 @@ chore:
 
 tests:
   - head-branch: ['^tests/', '^test/']
-  - changed-files: 'tests/**/*'
+  - changed-files:
+    - any-glob-to-any-file: 'tests/**/*'
 
 documentation:
   - head-branch: ['^docs/', '^doc/']
-  - changed-files: '**/*.md'
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
 
 dependencies:
-  - head-branch: ['^deps/', '^dep/', '^dependabot/']
-  - changed-files: ['go.mod', 'go.sum']
+  - head-branch: ['^deps/', '^dep/', '^dependabot/', 'pre-commit-ci-update-config']
+  - changed-files:
+    - any-glob-to-any-file: ['go.mod', 'go.sum']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write # for actions/labeler to add labels
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/labeler@4f052778de9a9b80cb16cfb9079b02287285a4cb # v5.0.0-alpha.1
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
### Proposed changes

Updates labeler action and its configuration to use https://github.com/actions/labeler/releases/tag/v5.0.0
