### PR TITLE
Update keepalive field for http upstreams

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -361,7 +361,7 @@ type Upstream struct {
 	Zone       string
 	Peers      []Peer
 	Queue      Queue
-	Keepalives int
+	Keepalive  int
 	Zombies    int
 }
 

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -358,11 +358,11 @@ type Upstreams map[string]Upstream
 
 // Upstream represents upstream related stats.
 type Upstream struct {
-	Zone       string
-	Peers      []Peer
-	Queue      Queue
-	Keepalive  int
-	Zombies    int
+	Zone      string
+	Peers     []Peer
+	Queue     Queue
+	Keepalive int
+	Zombies   int
 }
 
 // StreamUpstreams is a map of stream upstream stats by upstream name.


### PR DESCRIPTION
### Proposed changes

According to the docs here https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream, the keepalive field is called `keepalive` not `keepalives`.
This PR fixes the field name in the Upstream struct.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
