### PR TITLE
Automatically close milestones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [stable]
+        go-version: ["1.21", stable]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -99,6 +99,7 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: stable
+        if: ${{ github.ref_type == 'tag' }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,3 +10,6 @@ announce:
     enabled: true
     channel: "#announcements"
     message_template: "NGINX Plus Go Client {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}"
+
+milestones:
+  - close: true


### PR DESCRIPTION
### Proposed changes

Adds missing setting to `goreleaser` and runs the `setup-go` action only on release.
Adds go 1.21 to the matrix of versions to test.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
