### PR TITLE
Add doctoc to automatically generate TOCs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,5 +38,11 @@ repos:
     hooks:
       - id: yamllint
 
+  - repo: https://github.com/thlorenz/doctoc
+    rev: v2.2.0
+    hooks:
+      - id: doctoc
+        args: [--update-only, --title, "## Table of Contents"]
+
 ci:
   skip: [golangci-lint-full]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,20 +3,22 @@
 The following is a set of guidelines for contributing to the NGINX Plus Go Client. We really appreciate that you are
 considering contributing!
 
-## Table Of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
 
-[Ask a Question](#ask-a-question)
+- [Ask a Question](#ask-a-question)
+- [Getting Started](#getting-started)
+- [Contributing](#contributing)
+  - [Report a Bug](#report-a-bug)
+  - [Suggest an Enhancement](#suggest-an-enhancement)
+  - [Open a Pull Request](#open-a-pull-request)
+  - [Issue lifecycle](#issue-lifecycle)
+- [Style Guides](#style-guides)
+  - [Git Style Guide](#git-style-guide)
+  - [Go Style Guide](#go-style-guide)
 
-[Getting Started](#getting-started)
-
-[Contributing](#contributing)
-
-[Style Guides](#style-guides)
-
-- [Git Style Guide](#git-style-guide)
-- [Go Style Guide](#go-style-guide)
-
-[Code of Conduct](CODE_OF_CONDUCT.md)
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Ask a Question
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- markdownlint-disable-next-line first-line-h1 -->
 [![OpenSSFScorecard](https://api.securityscorecards.dev/projects/github.com/nginxinc/nginx-plus-go-client/badge)](https://api.securityscorecards.dev/projects/github.com/nginxinc/nginx-plus-go-client)
 [![Continuous Integration](https://github.com/nginxinc/nginx-plus-go-client/workflows/Continuous%20Integration/badge.svg)](https://github.com/nginxinc/nginx-plus-go-client/actions)
@@ -14,6 +13,22 @@
 # NGINX Plus Go Client
 
 This project includes a client library for working with NGINX Plus API.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [About the Client](#about-the-client)
+- [Compatibility](#compatibility)
+- [Using the Client](#using-the-client)
+- [Testing](#testing)
+  - [Unit tests](#unit-tests)
+  - [Integration tests](#integration-tests)
+- [Contacts](#contacts)
+- [Contributing](#contributing)
+- [Support](#support)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## About the Client
 

--- a/release-process.md
+++ b/release-process.md
@@ -2,6 +2,16 @@
 
 This document outlines the steps involved in the release process for the NGINX Plus Go Client project.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Versioning](#versioning)
+- [Release Planning and Development](#release-planning-and-development)
+- [Releasing a New Version](#releasing-a-new-version)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Versioning
 
 The project follows [Semantic Versioning](https://semver.org/) for versioning.


### PR DESCRIPTION
### Proposed changes

The Contributing Guidelines had new sections that were never added to the TOC.

With doctoc we can keep the TOCs up to date automatically.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
