### PR TITLE
Add go 1.22 to unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21", stable]
+        go-version: ["1.21", "1.22", stable]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,7 +29,7 @@ services:
       service: nginx
 
   test:
-    image: golang:1.21
+    image: golang:1.23
     volumes:
       - type: bind
         source: ./


### PR DESCRIPTION
### Proposed changes

Now that go 1.23 is stable, we want to add 1.22 to the list of versions we test.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
