### PR TITLE
Add permissions for GoReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      issues: write
     if: ${{ github.event.repository.fork == false }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
### Proposed changes

GoReleaser needs write permissions to automatically close milestones. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
