### PR TITLE
Skip dependency review run on merge queue

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,10 @@ jobs:
       contents: read # for actions/checkout
       pull-requests: write # for actions/dependency-review-action to post comments
     steps:
+      - name: Skip on Merge Group
+        run: exit 0 # Artifically flag as successful, as this is a required check for branch protection.
+        if: github.event_name == 'merge_group'
+
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint
+    name: Go Lint
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
### Proposed changes

The `actions/dependency-review-action` only works on PRs and we want to enforce the check. There's no option to enforce a check only on PR and not on Merge Queue. This makes the run in the Merge Queue pass.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
