### PR TITLE
Remove community slack announcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,5 +112,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMMUNITY }}
         if: ${{ github.ref_type == 'tag' }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,11 +5,5 @@ builds:
 changelog:
   disable: true
 
-announce:
-  slack:
-    enabled: true
-    channel: "#announcements"
-    message_template: "NGINX Plus Go Client {{ .Tag }} is out! Check it out: {{ .ReleaseURL }}"
-
 milestones:
   - close: true


### PR DESCRIPTION
### Proposed changes

The announcement to the (disabled) community slack #announce channel was failing on release.  The change removes the announcement.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-plus-go-client/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
